### PR TITLE
Documentation generation fix, set UMXController Ctor parameterless

### DIFF
--- a/DirectOutput/Cab/Out/AdressableLedStrip/UMXController/UMXController.cs
+++ b/DirectOutput/Cab/Out/AdressableLedStrip/UMXController/UMXController.cs
@@ -37,11 +37,7 @@ namespace DirectOutput.Cab.Out.AdressableLedStrip
         /// <summary>
         /// Initializes a new instance of the <see cref="UMXController"/> class with a given unit number.
         /// </summary>
-        /// <param name="Number">The number of the UMX controller.</param>
-        public UMXController(int Number)
-        {
-            this.Number = Number;
-        }
+        public UMXController(){}
 
 
         #region Number

--- a/DirectOutput/Cab/Out/AdressableLedStrip/UMXController/UMXControllerAutoConfigurator.cs
+++ b/DirectOutput/Cab/Out/AdressableLedStrip/UMXController/UMXControllerAutoConfigurator.cs
@@ -36,7 +36,7 @@ namespace DirectOutput.Cab.Out.AdressableLedStrip
                     //Because Autoconfig are not sorted, this one could already have done its AutoConfig call before some implementations
                     //So adding new controller to cabinet there, didn't happen with Dude's cab UMX implementation.
                     if (inited && cabinet != null) {
-                        UMXController umxC = new UMXController(dev.UnitNo());
+                        UMXController umxC = new UMXController() { Number = dev.UnitNo() };
                         Log.Instrumentation("UMX", $"Adding new device {dev.name} & controller {umxC.Name} to cabinet after UMXControllerAutoConfigurator initialization");
                         umxC.UpdateCabinetFromConfig(cabinet);
                     }
@@ -69,7 +69,7 @@ namespace DirectOutput.Cab.Out.AdressableLedStrip
             List<int> Preconfigured = new List<int>(Cabinet.OutputControllers.Where(OC => OC is UMXController).Select(C => ((UMXController)C).Number));
             foreach (var device in UMXControllerAutoConfigurator.AllDevices()) {
                 if (!Preconfigured.Contains(device.UnitNo())) {
-                    UMXController umxC = new UMXController(device.UnitNo());
+                    UMXController umxC = new UMXController() { Number = device.UnitNo() };
                     umxC.UpdateCabinetFromConfig(cabinet);
                 }
             }


### PR DESCRIPTION
Should fix the Generate Documentation action.

Had to modify docs.yml tho to correctly copy build outputs (x86 Debug or Release) into bin/Release to make it work.
DirectOutput & DocumentationHelper were formerly building into bin/Release for x86 build, now it's in bin/x86/Release
Not used to Github Actions so dunno if it was a local issue on my fork or not.