### PR TITLE
Directoutput initialization speedups

### DIFF
--- a/DirectOutput/FX/MatrixFX/MatrixBitmapAnimationEffectBase.cs
+++ b/DirectOutput/FX/MatrixFX/MatrixBitmapAnimationEffectBase.cs
@@ -356,7 +356,7 @@ namespace DirectOutput.FX.MatrixFX
                                 for (int s = 0; s < StepCount; s++)
                                 {
                                     
-                                    Pixels[s] = BM.Frames[BitmapFrameNumber + s].GetClip(AreaWidth, AreaHeight, BitmapLeft, BitmapTop, BitmapWidth, BitmapHeight, DataExtractMode).Pixels;
+                                    Pixels[s] = BM.Frames[BitmapFrameNumber + s].GetClip(AreaWidth, AreaHeight, BitmapLeft, BitmapTop, BitmapWidth, BitmapHeight, DataExtractMode, UseCache: Table.Pinball.GlobalConfig.FastInitialization).Pixels;
                                 }
 
 
@@ -370,7 +370,7 @@ namespace DirectOutput.FX.MatrixFX
 
                                 for (int s = 0; s < StepCount; s++)
                                 {
-                                    Pixels[s] = BM.Frames[BitmapFrameNumber].GetClip(AreaWidth, AreaHeight, BitmapLeft+s*AnimationStepSize, BitmapTop, BitmapWidth, BitmapHeight, DataExtractMode).Pixels;
+                                    Pixels[s] = BM.Frames[BitmapFrameNumber].GetClip(AreaWidth, AreaHeight, BitmapLeft+s*AnimationStepSize, BitmapTop, BitmapWidth, BitmapHeight, DataExtractMode, UseCache: Table.Pinball.GlobalConfig.FastInitialization).Pixels;
                                 }
 
                                 break;
@@ -380,7 +380,7 @@ namespace DirectOutput.FX.MatrixFX
 
                                 for (int s = 0; s < StepCount; s++)
                                 {
-                                    Pixels[s] = BM.Frames[BitmapFrameNumber].GetClip(AreaWidth, AreaHeight, BitmapLeft, BitmapTop + s * AnimationStepSize, BitmapWidth, BitmapHeight, DataExtractMode).Pixels;
+                                    Pixels[s] = BM.Frames[BitmapFrameNumber].GetClip(AreaWidth, AreaHeight, BitmapLeft, BitmapTop + s * AnimationStepSize, BitmapWidth, BitmapHeight, DataExtractMode, UseCache: Table.Pinball.GlobalConfig.FastInitialization).Pixels;
                                 }
 
                                 break;
@@ -389,7 +389,7 @@ namespace DirectOutput.FX.MatrixFX
                                 Pixels = new PixelData[StepCount][,];
                                 for (int s = 0; s < StepCount; s++)
                                 {
-                                    Pixels[s] = BM.Frames[BitmapFrameNumber].GetClip(AreaWidth, AreaHeight, BitmapLeft, BitmapTop, BitmapWidth, BitmapHeight, DataExtractMode).Pixels;
+                                    Pixels[s] = BM.Frames[BitmapFrameNumber].GetClip(AreaWidth, AreaHeight, BitmapLeft, BitmapTop, BitmapWidth, BitmapHeight, DataExtractMode, UseCache: Table.Pinball.GlobalConfig.FastInitialization).Pixels;
                                 }
                                 break;
                         }

--- a/DirectOutput/FX/MatrixFX/MatrixBitmapAnimationEffectBase.cs
+++ b/DirectOutput/FX/MatrixFX/MatrixBitmapAnimationEffectBase.cs
@@ -308,6 +308,7 @@ namespace DirectOutput.FX.MatrixFX
 
         private bool InitOK = false;
 
+        private readonly List<string> ExtensionExclusion = new List<string>() { FastImage.RawImageExtension };
 
         /// <summary>
         /// Initializes the effect.
@@ -324,7 +325,7 @@ namespace DirectOutput.FX.MatrixFX
             if (BitmapFilePattern.IsValid)
             {
 
-                string Filename = BitmapFilePattern.GetFirstMatchingFile(Table.Pinball.GlobalConfig.GetReplaceValuesDictionary())?.FullName ?? string.Empty;
+                string Filename = BitmapFilePattern.GetFirstMatchingFile(Table.Pinball.GlobalConfig.GetReplaceValuesDictionary(), ExtensionExclusion)?.FullName ?? string.Empty;
                 if (!Filename.IsNullOrWhiteSpace())
                 {
                     FastImage BM;

--- a/DirectOutput/FX/MatrixFX/MatrixBitmapEffectBase.cs
+++ b/DirectOutput/FX/MatrixFX/MatrixBitmapEffectBase.cs
@@ -192,7 +192,7 @@ namespace DirectOutput.FX.MatrixFX
                     if (BM.Frames.ContainsKey(BitmapFrameNumber))
                     {
                         Log.Instrumentation("MX", "BitmapEffectBase. Grabbing image clip: W: {0}, H:{1}, BML: {2}, BMT: {3}, BMW: {4}, BMH: {5}".Build(new object[] { AreaWidth, AreaHeight, BitmapLeft, BitmapTop, BitmapWidth, BitmapHeight }));
-                        Pixels = BM.Frames[BitmapFrameNumber].GetClip(AreaWidth, AreaHeight, BitmapLeft, BitmapTop, BitmapWidth, BitmapHeight, DataExtractMode).Pixels;
+                        Pixels = BM.Frames[BitmapFrameNumber].GetClip(AreaWidth, AreaHeight, BitmapLeft, BitmapTop, BitmapWidth, BitmapHeight, DataExtractMode, UseCache: Table.Pinball.GlobalConfig.FastInitialization).Pixels;
 
                     }
                     else

--- a/DirectOutput/FX/MatrixFX/MatrixBitmapEffectBase.cs
+++ b/DirectOutput/FX/MatrixFX/MatrixBitmapEffectBase.cs
@@ -159,6 +159,7 @@ namespace DirectOutput.FX.MatrixFX
 
         private bool InitOK = false;
 
+        private readonly List<string> ExtensionExclusion = new List<string>() { FastImage.RawImageExtension };
 
         /// <summary>
         /// Initializes the effect.
@@ -174,7 +175,7 @@ namespace DirectOutput.FX.MatrixFX
             //TODO: Insert replace values for file pattern
             if (BitmapFilePattern.IsValid)
             {
-                FileInfo FI = BitmapFilePattern.GetFirstMatchingFile(Table.Pinball.GlobalConfig.GetReplaceValuesDictionary());
+                FileInfo FI = BitmapFilePattern.GetFirstMatchingFile(Table.Pinball.GlobalConfig.GetReplaceValuesDictionary(), ExtensionExclusion);
                 if (FI!=null && FI.Exists)
                 {
                     FastImage BM;

--- a/DirectOutput/FX/MatrixFX/RGBAMatrixColorScaleBitmapEffect.cs
+++ b/DirectOutput/FX/MatrixFX/RGBAMatrixColorScaleBitmapEffect.cs
@@ -77,16 +77,7 @@ namespace DirectOutput.FX.MatrixFX
 
                     for (int X = 0; X <= Pixels.GetUpperBound(0); X++)
                     {
-                        PixelData P = Pixels[X, Y];
-
-                        double Brightness = ((double)(P.Red + P.Green + P.Blue) / 3).Limit(0, 255);
-
-                        P.Red = (byte)(InactiveColor.Red + (int)((float)(ActiveColor.Red - InactiveColor.Red) * Brightness / 255)).Limit(0, 255);
-                        P.Green = (byte)(InactiveColor.Green + (int)((float)(ActiveColor.Green - InactiveColor.Green) * Brightness / 255)).Limit(0, 255);
-                        P.Blue = (byte)(InactiveColor.Blue + (int)((float)(ActiveColor.Blue - InactiveColor.Blue) * Brightness / 255)).Limit(0, 255);
-                        P.Alpha = (byte)(InactiveColor.Alpha + (int)((float)(ActiveColor.Alpha - InactiveColor.Alpha) * Brightness / 255)).Limit(0, 255);
-                        Pixels[X, Y] = P;
-
+                        Pixels[X, Y].Colorize(ActiveColor, InactiveColor);
                     }
 
                 }

--- a/DirectOutput/FX/MatrixFX/RGBAMatrixColorScaleBitmapEffect.cs
+++ b/DirectOutput/FX/MatrixFX/RGBAMatrixColorScaleBitmapEffect.cs
@@ -74,20 +74,12 @@ namespace DirectOutput.FX.MatrixFX
             {
                 for (int Y = 0; Y <= Pixels.GetUpperBound(1); Y++)
                 {
-
                     for (int X = 0; X <= Pixels.GetUpperBound(0); X++)
                     {
                         Pixels[X, Y].Colorize(ActiveColor, InactiveColor);
                     }
-
                 }
-
-
             }
-
         }
-
-
-
     }
 }

--- a/DirectOutput/General/BitmapHandling/FastBitmap.cs
+++ b/DirectOutput/General/BitmapHandling/FastBitmap.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Drawing;
+using System.IO;
 
 namespace DirectOutput.General.BitmapHandling
 {
@@ -358,7 +359,25 @@ namespace DirectOutput.General.BitmapHandling
             GC.Collect();
         }
 
-
+        /// <summary>
+        /// Load the Fastbitmap using a Binary Reader.
+        /// <param name="Reader">The binary reader.</param>
+        /// </summary>
+        public void Load(BinaryReader Reader)
+        {
+            int W = Reader.ReadInt32();
+            int H = Reader.ReadInt32();
+            SetFrameSize(W, H);
+            PixelData[,] P = Pixels;
+            for (int y = 0; y < Height; y++) {
+                for (int x = 0; x < Width; x++) {
+                    P[x, y].Alpha = Reader.ReadByte();
+                    P[x, y].Red = Reader.ReadByte();
+                    P[x, y].Green = Reader.ReadByte();
+                    P[x, y].Blue = Reader.ReadByte();
+                }
+            }
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FastBitmap"/> class.

--- a/DirectOutput/General/BitmapHandling/FastImage.cs
+++ b/DirectOutput/General/BitmapHandling/FastImage.cs
@@ -25,6 +25,14 @@ namespace DirectOutput.General.BitmapHandling
             private set { _Frames = value; }
         }
 
+        private bool _UseCache = false;
+
+        public bool UseCache
+        {
+            get { return _UseCache; }
+            set { _UseCache = value; }
+        }
+
         public static string RawImageExtension => ".rawimage";
 
         private bool LoadCachedImage(string ImageFilePath)
@@ -91,7 +99,7 @@ namespace DirectOutput.General.BitmapHandling
         {
             Frames = new Dictionary<int, FastBitmap>();
 
-            if (!LoadCachedImage(ImageFilePath)) 
+            if (!UseCache || !LoadCachedImage(ImageFilePath)) 
             {
                 Log.Instrumentation("Image", $"Loading image file {ImageFilePath}.");
                 Image Img = Image.FromFile(ImageFilePath);
@@ -113,7 +121,9 @@ namespace DirectOutput.General.BitmapHandling
                 Img.Dispose();
                 Log.Instrumentation("Image", $"Image loaded.");
 
-                SaveCachedImage(ImageFilePath);
+                if (UseCache) {
+                    SaveCachedImage(ImageFilePath);
+                }
             }
         }
 
@@ -124,8 +134,9 @@ namespace DirectOutput.General.BitmapHandling
         }
 
 
-        public FastImage(string Name) :this()
+        public FastImage(string Name, bool UseCache = false) :this()
         {
+            this.UseCache = UseCache;
             this.Name = Name;
         }
 

--- a/DirectOutput/General/BitmapHandling/FastImage.cs
+++ b/DirectOutput/General/BitmapHandling/FastImage.cs
@@ -35,9 +35,16 @@ namespace DirectOutput.General.BitmapHandling
 
         public static string RawImageExtension => ".rawimage";
 
+        private static string GetCachedImagePath(string ImageFilePath)
+        {
+            return Path.Combine(
+                Path.GetDirectoryName(ImageFilePath),
+                "cache") + Path.DirectorySeparatorChar + Path.GetFileName(ImageFilePath) + RawImageExtension;
+        }
+
         private bool LoadCachedImage(string ImageFilePath)
         {
-            string CachedImageFilePath = ImageFilePath + RawImageExtension;
+            string CachedImageFilePath = GetCachedImagePath(ImageFilePath);
             try {
                 if (File.Exists(CachedImageFilePath)) {
                     if (File.GetLastWriteTimeUtc(CachedImageFilePath) > File.GetLastWriteTimeUtc(ImageFilePath)) {
@@ -67,8 +74,11 @@ namespace DirectOutput.General.BitmapHandling
 
         private void SaveCachedImage(string ImageFilePath)
         {
-            string CachedImageFilePath = ImageFilePath + RawImageExtension;
+            string CachedImageFilePath = GetCachedImagePath(ImageFilePath);
             try {
+                if (!Directory.Exists(Path.GetDirectoryName(CachedImageFilePath))){
+                    Directory.CreateDirectory(Path.GetDirectoryName(CachedImageFilePath));
+                }
                 using (var stream = File.Open(CachedImageFilePath, FileMode.Create)) {
                     using (var writer = new BinaryWriter(stream, Encoding.UTF8, false)) {
                         Log.Instrumentation("Image", $"Saving cached image file {CachedImageFilePath}, {Frames.Count} frames.");

--- a/DirectOutput/General/BitmapHandling/FastImage.cs
+++ b/DirectOutput/General/BitmapHandling/FastImage.cs
@@ -51,7 +51,7 @@ namespace DirectOutput.General.BitmapHandling
                     }
                 }
             } catch (Exception E) {
-                throw new Exception($"Could not load cached image file {CachedImageFilePath} to the FastBitmapList.\n{E}");
+                throw new Exception($"Could not load cached image file {CachedImageFilePath} to the FastBitmapList.\nYou can delete it so it can ge generated again.\n{E}");
             }
 
             return false;

--- a/DirectOutput/General/BitmapHandling/FastImage.cs
+++ b/DirectOutput/General/BitmapHandling/FastImage.cs
@@ -1,10 +1,12 @@
-﻿using System;
+﻿using DirectOutput.General.Generic;
+using Q42.HueApi;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using DirectOutput.General.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Text;
 
 namespace DirectOutput.General.BitmapHandling
 {
@@ -23,27 +25,94 @@ namespace DirectOutput.General.BitmapHandling
             private set { _Frames = value; }
         }
 
+        private bool LoadCachedImage(string ImageFilePath)
+        {
+            string CachedImageFilePath = ImageFilePath + ".raw";
+            try {
+                if (File.Exists(CachedImageFilePath)) {
+                    if (File.GetLastWriteTimeUtc(CachedImageFilePath) > File.GetLastWriteTimeUtc(ImageFilePath)) {
+                        using (var stream = File.Open(CachedImageFilePath, FileMode.Open, FileAccess.Read)) {
+                            using (var reader = new BinaryReader(stream, Encoding.UTF8, false)) {
+                                Log.Instrumentation("Image", $"Loading cached image file {CachedImageFilePath}.");
+                                int FrameCount = reader.ReadInt32();
+
+                                for (int FrameNumber = 0; FrameNumber < FrameCount; FrameNumber++) {
+                                    FastBitmap F = new FastBitmap();
+                                    F.Load(reader);
+                                    Frames.Add(FrameNumber, F);
+                                }
+
+                                Log.Instrumentation("Image", $"Loaded cached image file {FrameCount} frames.");
+                                return true;
+                            }
+                        }
+                    }
+                }
+            } catch (Exception E) {
+                throw new Exception($"Could not load cached image file {CachedImageFilePath} to the FastBitmapList.\n{E}");
+            }
+
+            return false;
+        }
+
+        private void SaveCachedImage(string ImageFilePath)
+        {
+            string CachedImageFilePath = ImageFilePath + ".raw";
+            try {
+                using (var stream = File.Open(CachedImageFilePath, FileMode.Create)) {
+                    using (var writer = new BinaryWriter(stream, Encoding.UTF8, false)) {
+                        Log.Instrumentation("Image", $"Saving cached image file {CachedImageFilePath}, {Frames.Count} frames.");
+                        writer.Write(Frames.Count);
+                        for (int FrameNumber = 0; FrameNumber < Frames.Count; FrameNumber++) {
+                            FastBitmap bitMap = Frames[FrameNumber];
+                            writer.Write(bitMap.Width);
+                            writer.Write(bitMap.Height);
+                            for (int y = 0; y < bitMap.Height; y++) {
+                                for (int x = 0; x < bitMap.Width; x++) {
+                                    PixelData pixelData = bitMap.GetPixel(x, y);
+                                    writer.Write(pixelData.Alpha);
+                                    writer.Write(pixelData.Red);
+                                    writer.Write(pixelData.Green);
+                                    writer.Write(pixelData.Blue);
+                                }
+                            }
+                        }
+                        Log.Instrumentation("Image", $"{CachedImageFilePath} saved (size {stream.Length} bytes).");
+                    }
+                }
+            } catch (Exception E) {
+                throw new Exception($"Could not save cached image file {CachedImageFilePath}.\n{E}");
+            }
+        }
+
         public void LoadImageFile(string ImageFilePath)
         {
             Frames = new Dictionary<int, FastBitmap>();
 
-            Image Img = Image.FromFile(ImageFilePath);
-
-            FrameDimension dimension = new FrameDimension(Img.FrameDimensionsList[0]);
-            // Number of frames
-            int FrameCount = Img.GetFrameCount(dimension);
-            // Return an Image at a certain index
-
-            for (int FrameNumber = 0; FrameNumber < FrameCount; FrameNumber++)
+            if (!LoadCachedImage(ImageFilePath)) 
             {
-                Img.SelectActiveFrame(dimension, FrameNumber);
+                Log.Instrumentation("Image", $"Loading image file {ImageFilePath}.");
+                Image Img = Image.FromFile(ImageFilePath);
 
-                FastBitmap F = new FastBitmap(Img);
+                FrameDimension dimension = new FrameDimension(Img.FrameDimensionsList[0]);
+                // Number of frames
+                int FrameCount = Img.GetFrameCount(dimension);
+                // Return an Image at a certain index
 
-                Frames.Add(FrameNumber, F);
+                Log.Instrumentation("Image", $"Extracting {FrameCount} frames from image.");
+                for (int FrameNumber = 0; FrameNumber < FrameCount; FrameNumber++) {
+                    Img.SelectActiveFrame(dimension, FrameNumber);
+
+                    FastBitmap F = new FastBitmap(Img);
+
+                    Frames.Add(FrameNumber, F);
+                }
+
+                Img.Dispose();
+                Log.Instrumentation("Image", $"Image loaded.");
+
+                SaveCachedImage(ImageFilePath);
             }
-
-            Img.Dispose();
         }
 
 

--- a/DirectOutput/General/BitmapHandling/FastImage.cs
+++ b/DirectOutput/General/BitmapHandling/FastImage.cs
@@ -25,9 +25,11 @@ namespace DirectOutput.General.BitmapHandling
             private set { _Frames = value; }
         }
 
+        public static string RawImageExtension => ".rawimage";
+
         private bool LoadCachedImage(string ImageFilePath)
         {
-            string CachedImageFilePath = ImageFilePath + ".raw";
+            string CachedImageFilePath = ImageFilePath + RawImageExtension;
             try {
                 if (File.Exists(CachedImageFilePath)) {
                     if (File.GetLastWriteTimeUtc(CachedImageFilePath) > File.GetLastWriteTimeUtc(ImageFilePath)) {
@@ -57,7 +59,7 @@ namespace DirectOutput.General.BitmapHandling
 
         private void SaveCachedImage(string ImageFilePath)
         {
-            string CachedImageFilePath = ImageFilePath + ".raw";
+            string CachedImageFilePath = ImageFilePath + RawImageExtension;
             try {
                 using (var stream = File.Open(CachedImageFilePath, FileMode.Create)) {
                     using (var writer = new BinaryWriter(stream, Encoding.UTF8, false)) {

--- a/DirectOutput/General/BitmapHandling/FastImageList.cs
+++ b/DirectOutput/General/BitmapHandling/FastImageList.cs
@@ -23,7 +23,7 @@ namespace DirectOutput.General.BitmapHandling
                     {
                         try
                         {
-                            FastImage F = new FastImage(Name);
+                            FastImage F = new FastImage(Name, UseCache);
                             Add(F);
                             return F;
                         }
@@ -48,11 +48,12 @@ namespace DirectOutput.General.BitmapHandling
             set { _DontAddIfMissing = value; }
         }
 
+        private bool _UseCache = false;
 
-
-
-
-
-
+        public Boolean UseCache
+        {
+            get { return _UseCache; }
+            set { _UseCache = value; }
+        }
     }
 }

--- a/DirectOutput/General/BitmapHandling/PixelData.cs
+++ b/DirectOutput/General/BitmapHandling/PixelData.cs
@@ -27,6 +27,15 @@ namespace DirectOutput.General.BitmapHandling
             return new RGBAColor(Red, Green, Blue, Alpha);
         }
 
+        internal void Colorize(RGBAColor ActiveColor, RGBAColor InactiveColor)
+        {
+            double Brightness = ((double)(Red + Green + Blue) / 3).Limit(0, 255);
+
+            Red = (byte)(InactiveColor.Red + (int)((float)(ActiveColor.Red - InactiveColor.Red) * Brightness / 255)).Limit(0, 255);
+            Green = (byte)(InactiveColor.Green + (int)((float)(ActiveColor.Green - InactiveColor.Green) * Brightness / 255)).Limit(0, 255);
+            Blue = (byte)(InactiveColor.Blue + (int)((float)(ActiveColor.Blue - InactiveColor.Blue) * Brightness / 255)).Limit(0, 255);
+            Alpha = (byte)(InactiveColor.Alpha + (int)((float)(ActiveColor.Alpha - InactiveColor.Alpha) * Brightness / 255)).Limit(0, 255);
+        }
 
         public PixelData(byte Red, byte Green, byte Blue, byte Alpha)
         {

--- a/DirectOutput/General/FilePattern.cs
+++ b/DirectOutput/General/FilePattern.cs
@@ -120,6 +120,7 @@ namespace DirectOutput.General
         /// Gets the files matching the value of the property Pattern.
         /// </summary>
         /// <param name="ReplaceValues">Dictionary containing key/value pairs used to replace placeholders in the form {PlaceHolder} in the pattern.</param>
+        /// <param name="ExcludeExtensions">List of file extensions which should be ignored (in the for ".ext")</param>
         /// <returns>The list of files matching the value of the property Pattern or a empty list if no file matches the pattern.</returns>
         public List<FileInfo> GetMatchingFiles(Dictionary<string, string> ReplaceValues = null, List<string> ExcludeExtensions = null)
         {
@@ -154,6 +155,7 @@ namespace DirectOutput.General
         /// Gets the first file matching the value of the Pattern property.
         /// </summary>
         /// <param name="ReplaceValues">Dictionary containing key/value pairs used to replace placeholders in the form {PlaceHolder} in the pattern.</param>
+        /// <param name="ExcludeExtensions">List of file extensions which should be ignored (in the for ".ext")</param>
         /// <returns>The first file matching the value of the Pattern property or null if no file matches the pattern.</returns>
         public FileInfo GetFirstMatchingFile(Dictionary<string, string> ReplaceValues = null, List<string> ExcludeExtensions = null)
         {

--- a/DirectOutput/General/FilePattern.cs
+++ b/DirectOutput/General/FilePattern.cs
@@ -1,7 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 using System.Xml.Serialization;
 
@@ -119,7 +121,7 @@ namespace DirectOutput.General
         /// </summary>
         /// <param name="ReplaceValues">Dictionary containing key/value pairs used to replace placeholders in the form {PlaceHolder} in the pattern.</param>
         /// <returns>The list of files matching the value of the property Pattern or a empty list if no file matches the pattern.</returns>
-        public List<FileInfo> GetMatchingFiles(Dictionary<string, string> ReplaceValues = null)
+        public List<FileInfo> GetMatchingFiles(Dictionary<string, string> ReplaceValues = null, List<string> ExcludeExtensions = null)
         {
             if (Pattern.IsNullOrWhiteSpace()) return new List<FileInfo>();
 
@@ -131,11 +133,13 @@ namespace DirectOutput.General
 
                 DirectoryInfo FilesDirectory = new DirectoryInfo((Path.GetDirectoryName(P).IsNullOrWhiteSpace() ? "." : Path.GetDirectoryName(P)));
 
-                if (FilesDirectory.Exists)
-                {
-                    return FilesDirectory.GetFiles(Path.GetFileName(P)).ToList<FileInfo>();
-                }
-                else
+                if (FilesDirectory.Exists) {
+                    List<FileInfo> Files = FilesDirectory.GetFiles(Path.GetFileName(P)).ToList<FileInfo>();
+                    Files.RemoveAll(FI => ExcludeExtensions != null &&
+                                    ExcludeExtensions.Contains(FI.Extension, StringComparer.InvariantCultureIgnoreCase)
+                                    );
+                    return Files;
+                } else
                 {
                     return new List<FileInfo>();
                 }
@@ -151,9 +155,9 @@ namespace DirectOutput.General
         /// </summary>
         /// <param name="ReplaceValues">Dictionary containing key/value pairs used to replace placeholders in the form {PlaceHolder} in the pattern.</param>
         /// <returns>The first file matching the value of the Pattern property or null if no file matches the pattern.</returns>
-        public FileInfo GetFirstMatchingFile(Dictionary<string, string> ReplaceValues = null)
+        public FileInfo GetFirstMatchingFile(Dictionary<string, string> ReplaceValues = null, List<string> ExcludeExtensions = null)
         {
-            List<FileInfo> L = GetMatchingFiles(ReplaceValues);
+            List<FileInfo> L = GetMatchingFiles(ReplaceValues, ExcludeExtensions);
             if (L.Count > 0)
             {
                 return L[0];

--- a/DirectOutput/General/Generic/NamedItemBase.cs
+++ b/DirectOutput/General/Generic/NamedItemBase.cs
@@ -32,8 +32,6 @@ namespace DirectOutput.General.Generic
                     _Name = value;
                     AfterNameChange(OldName, value);
                     OnAfterNameChanged(OldName, value);
-
-            
                 }
             }
         }

--- a/DirectOutput/GlobalConfiguration/GlobalConfig.cs
+++ b/DirectOutput/GlobalConfiguration/GlobalConfig.cs
@@ -487,7 +487,21 @@ namespace DirectOutput.GlobalConfiguration
 
         #endregion
 
+        #region FastInit
+        private bool _FastInitialization = true;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether important events in the framework are logged to a file.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if logging is enabled, <c>false</c> if logging is disabled.
+        /// </value>
+        public bool FastInitialization
+        {
+            get { return _FastInitialization; }
+            set { _FastInitialization = value; }
+        }
+        #endregion 
 
         internal Dictionary<string, string> GetReplaceValuesDictionary(string TableFileName = null, string RomName = "")
         {

--- a/DirectOutput/LedControl/Loader/LedControlConfig.cs
+++ b/DirectOutput/LedControl/Loader/LedControlConfig.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Linq;
+using DirectOutput.GlobalConfiguration;
 
 namespace DirectOutput.LedControl.Loader
 {
@@ -82,6 +83,7 @@ namespace DirectOutput.LedControl.Loader
         /// </summary>
         /// <param name="LedControlIniFile">The ledcontrol.ini FileInfo object.</param>
         /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
+        /// <param name="GlobalConfig">The current global configuration.</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> [throw exceptions].</param>
         /// <exception cref="System.Exception">
         /// File {0} does not contain data.
@@ -92,7 +94,7 @@ namespace DirectOutput.LedControl.Loader
         /// or
         /// Section {0} of file {1} does not have the same number of columns in all lines.
         /// </exception>
-        private void ParseLedControlIni(FileInfo LedControlIniFile, string RomName, bool ThrowExceptions = false)
+        private void ParseLedControlIni(FileInfo LedControlIniFile, string RomName, GlobalConfig GlobalConfig, bool ThrowExceptions = false)
         {
             string[] ColorStartStrings = { "[Colors DOF]", "[Colors LedWiz]" };
             string[] OutStartStrings = { "[Config DOF]", "[Config outs]" };
@@ -278,7 +280,9 @@ namespace DirectOutput.LedControl.Loader
 
             ColorConfigurations.ParseLedControlData(ColorData, ThrowExceptions);
 
-            TableConfigurations.ParseLedcontrolData(OutData, RomName, ThrowExceptions);
+            Log.Write($"Parsing Tables Configurations ({LedControlIniFile})");
+            TableConfigurations.ParseLedcontrolData(OutData, RomName, GlobalConfig, ThrowExceptions);
+            Log.Write($"{TableConfigurations.Count} Tables Configurations parsed.");
 
             //ResolveOutputNumbers();
             ResolveRGBColors();
@@ -445,6 +449,7 @@ namespace DirectOutput.LedControl.Loader
         /// <param name="LedControlIniFilename">The ledcontrol.ini filename.</param>
         /// <param name="LedWizNumber">The number of the LedWizEquivalent to be used.</param>
         /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
+        /// <param name="GlobalConfig">The current global configuration.</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> [throw exceptions].</param>
         /// <exception cref="System.Exception">File {0} does not contain data.
         /// or
@@ -453,10 +458,10 @@ namespace DirectOutput.LedControl.Loader
         /// File {1} does not contain data in the {0} section.
         /// or
         /// Section {0} of file {1} does not have the same number of columns in all lines.</exception>
-        public LedControlConfig(string LedControlIniFilename, int LedWizNumber, string RomName, bool ThrowExceptions = false)
+        public LedControlConfig(string LedControlIniFilename, int LedWizNumber, string RomName, GlobalConfig GlobalConfig, bool ThrowExceptions = false)
             : this()
         {
-            ParseLedControlIni(new FileInfo(LedControlIniFilename), RomName, ThrowExceptions);
+            ParseLedControlIni(new FileInfo(LedControlIniFilename), RomName, GlobalConfig, ThrowExceptions);
             this.LedWizNumber = LedWizNumber;
         }
 
@@ -467,6 +472,7 @@ namespace DirectOutput.LedControl.Loader
         /// <param name="LedControlIniFile">The ledcontrol.ini FileInfo object.</param>
         /// <param name="LedWizNumber">The number of the LedWizEquivalent to be used.</param>
         /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
+        /// <param name="GlobalConfig">The current global configuration.</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> [throw exceptions].</param>
         /// <exception cref="System.Exception">File {0} does not contain data.
         /// or
@@ -475,10 +481,10 @@ namespace DirectOutput.LedControl.Loader
         /// File {1} does not contain data in the {0} section.
         /// or
         /// Section {0} of file {1} does not have the same number of columns in all lines.</exception>
-        public LedControlConfig(FileInfo LedControlIniFile, int LedWizNumber, string RomName, bool ThrowExceptions = false)
+        public LedControlConfig(FileInfo LedControlIniFile, int LedWizNumber, string RomName, GlobalConfig GlobalConfig, bool ThrowExceptions = false)
             : this()
         {
-            ParseLedControlIni(LedControlIniFile, RomName, ThrowExceptions);
+            ParseLedControlIni(LedControlIniFile, RomName, GlobalConfig, ThrowExceptions);
             this.LedWizNumber = LedWizNumber;
         }
 

--- a/DirectOutput/LedControl/Loader/LedControlConfig.cs
+++ b/DirectOutput/LedControl/Loader/LedControlConfig.cs
@@ -110,19 +110,19 @@ namespace DirectOutput.LedControl.Loader
             }
             catch (Exception E)
             {
-                Log.Exception("Could not read file {0}.".Build(LedControlIniFile), E);
+                Log.Exception($"Could not read file {LedControlIniFile}.", E);
                 if (ThrowExceptions)
                 {
 
-                    throw new Exception("Could not read file {0}.".Build(LedControlIniFile), E);
+                    throw new Exception($"Could not read file {LedControlIniFile}.", E);
                 }
             }
             if (FileData.IsNullOrWhiteSpace())
             {
-                Log.Warning("File {0} does not contain data.".Build(LedControlIniFile));
+                Log.Warning($"File {LedControlIniFile} does not contain data.");
                 if (ThrowExceptions)
                 {
-                    throw new Exception("File {0} does not contain data.".Build(LedControlIniFile));
+                    throw new Exception($"File {LedControlIniFile} does not contain data.");
                 }
             }
             #endregion
@@ -146,12 +146,12 @@ namespace DirectOutput.LedControl.Loader
                             if (Sections.ContainsKey(SectionHeader))
                             {
                                 int Cnt = 2;
-                                while (Sections.ContainsKey("{0} {1}".Build(SectionHeader, Cnt)))
+                                while (Sections.ContainsKey($"{SectionHeader} {Cnt}"))
                                 {
                                     Cnt++;
-                                    if (Cnt > 999) { throw new Exception("Section header {0} exists to many times.".Build(SectionHeader)); }
+                                    if (Cnt > 999) { throw new Exception($"Section header {SectionHeader} exists to many times."); }
                                 }
-                                SectionHeader = "{0} {1}".Build(SectionHeader, Cnt);
+                                SectionHeader = $"{SectionHeader} {Cnt}";
                             }
                             Sections.Add(SectionHeader, SectionData);
                             SectionData = new List<string>();
@@ -171,12 +171,12 @@ namespace DirectOutput.LedControl.Loader
                 if (Sections.ContainsKey(SectionHeader))
                 {
                     int Cnt = 2;
-                    while (Sections.ContainsKey("{0} {1}".Build(SectionHeader, Cnt)))
+                    while (Sections.ContainsKey($"{SectionHeader} {Cnt}"))
                     {
                         Cnt++;
-                        if (Cnt > 999) { throw new Exception("Section header {0} exists to many times.".Build(SectionHeader)); }
+                        if (Cnt > 999) { throw new Exception($"Section header {SectionHeader} exists to many times."); }
                     }
-                    SectionHeader = "{0} {1}".Build(SectionHeader, Cnt);
+                    SectionHeader = $"{SectionHeader} {Cnt}";
                 }
                 Sections.Add(SectionHeader, SectionData);
                 SectionData = new List<string>();
@@ -225,7 +225,7 @@ namespace DirectOutput.LedControl.Loader
             }
             else
             {
-                Log.Warning("No version section found in file {0}.".Build(LedControlIniFile));
+                Log.Warning($"No version section found in file {LedControlIniFile}.");
             }
 
             if (ColorData == null)
@@ -252,33 +252,35 @@ namespace DirectOutput.LedControl.Loader
                 Log.Warning("Could not find table config section in file {0}.".Build(LedControlIniFile));
                 if (ThrowExceptions)
                 {
-                    throw new Exception("Could not find table config section section in file {1}.".Build(LedControlIniFile));
+                    throw new Exception($"Could not find table config section section in file {LedControlIniFile}.");
                 }
                 return;
             }
             else if (OutData.Count < 1)
             {
-                Log.Warning("File {0} does not contain data in the table config section.".Build(LedControlIniFile));
+                Log.Warning($"File {LedControlIniFile} does not contain data in the table config section.");
                 if (ThrowExceptions)
                 {
-                    throw new Exception("File {0} does not contain data in the table config section".Build(LedControlIniFile));
+                    throw new Exception($"File {LedControlIniFile} does not contain data in the table config section");
                 }
                 return;
             }
 
             //Resolve tables variables first in case they override global variables (like custom flasher mx shapes)
             if (TableVariableData != null) {
-                Log.Write("Resolving Tables Variables ({0})".Build(LedControlIniFile));
+                Log.Write($"Resolving Tables Variables ({LedControlIniFile})");
                 ResolveTableVariables(OutData, TableVariableData);
             }
 
             if (VariableData != null)
             {
-                Log.Write("Resolving Global Variables ({0})".Build(LedControlIniFile));
+                Log.Write($"Resolving Global Variables ({LedControlIniFile})");
                 ResolveVariables(OutData, VariableData);
             }
 
+            Log.Write($"Parsing Color Configurations ({LedControlIniFile})");
             ColorConfigurations.ParseLedControlData(ColorData, ThrowExceptions);
+            Log.Write($"{ColorConfigurations.Count} Color Configurations parsed.");
 
             Log.Write($"Parsing Tables Configurations ({LedControlIniFile})");
             TableConfigurations.ParseLedcontrolData(OutData, RomName, GlobalConfig, ThrowExceptions);

--- a/DirectOutput/LedControl/Loader/LedControlConfig.cs
+++ b/DirectOutput/LedControl/Loader/LedControlConfig.cs
@@ -81,6 +81,7 @@ namespace DirectOutput.LedControl.Loader
         /// Parses the ledcontrol.ini file.
         /// </summary>
         /// <param name="LedControlIniFile">The ledcontrol.ini FileInfo object.</param>
+        /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> [throw exceptions].</param>
         /// <exception cref="System.Exception">
         /// File {0} does not contain data.
@@ -91,7 +92,7 @@ namespace DirectOutput.LedControl.Loader
         /// or
         /// Section {0} of file {1} does not have the same number of columns in all lines.
         /// </exception>
-        private void ParseLedControlIni(FileInfo LedControlIniFile, bool ThrowExceptions = false)
+        private void ParseLedControlIni(FileInfo LedControlIniFile, string RomName, bool ThrowExceptions = false)
         {
             string[] ColorStartStrings = { "[Colors DOF]", "[Colors LedWiz]" };
             string[] OutStartStrings = { "[Config DOF]", "[Config outs]" };
@@ -277,7 +278,7 @@ namespace DirectOutput.LedControl.Loader
 
             ColorConfigurations.ParseLedControlData(ColorData, ThrowExceptions);
 
-            TableConfigurations.ParseLedcontrolData(OutData, ThrowExceptions);
+            TableConfigurations.ParseLedcontrolData(OutData, RomName, ThrowExceptions);
 
             //ResolveOutputNumbers();
             ResolveRGBColors();
@@ -443,6 +444,7 @@ namespace DirectOutput.LedControl.Loader
         /// </summary>
         /// <param name="LedControlIniFilename">The ledcontrol.ini filename.</param>
         /// <param name="LedWizNumber">The number of the LedWizEquivalent to be used.</param>
+        /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> [throw exceptions].</param>
         /// <exception cref="System.Exception">File {0} does not contain data.
         /// or
@@ -451,10 +453,10 @@ namespace DirectOutput.LedControl.Loader
         /// File {1} does not contain data in the {0} section.
         /// or
         /// Section {0} of file {1} does not have the same number of columns in all lines.</exception>
-        public LedControlConfig(string LedControlIniFilename, int LedWizNumber, bool ThrowExceptions = false)
+        public LedControlConfig(string LedControlIniFilename, int LedWizNumber, string RomName, bool ThrowExceptions = false)
             : this()
         {
-            ParseLedControlIni(new FileInfo(LedControlIniFilename), ThrowExceptions);
+            ParseLedControlIni(new FileInfo(LedControlIniFilename), RomName, ThrowExceptions);
             this.LedWizNumber = LedWizNumber;
         }
 
@@ -464,6 +466,7 @@ namespace DirectOutput.LedControl.Loader
         /// </summary>
         /// <param name="LedControlIniFile">The ledcontrol.ini FileInfo object.</param>
         /// <param name="LedWizNumber">The number of the LedWizEquivalent to be used.</param>
+        /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> [throw exceptions].</param>
         /// <exception cref="System.Exception">File {0} does not contain data.
         /// or
@@ -472,10 +475,10 @@ namespace DirectOutput.LedControl.Loader
         /// File {1} does not contain data in the {0} section.
         /// or
         /// Section {0} of file {1} does not have the same number of columns in all lines.</exception>
-        public LedControlConfig(FileInfo LedControlIniFile, int LedWizNumber, bool ThrowExceptions = false)
+        public LedControlConfig(FileInfo LedControlIniFile, int LedWizNumber, string RomName, bool ThrowExceptions = false)
             : this()
         {
-            ParseLedControlIni(LedControlIniFile, ThrowExceptions);
+            ParseLedControlIni(LedControlIniFile, RomName, ThrowExceptions);
             this.LedWizNumber = LedWizNumber;
         }
 

--- a/DirectOutput/LedControl/Loader/LedControlConfigList.cs
+++ b/DirectOutput/LedControl/Loader/LedControlConfigList.cs
@@ -54,12 +54,13 @@ namespace DirectOutput.LedControl.Loader
         /// </summary>
         /// <param name="LedControlFilenames">The list of ledcontrol.ini files</param>
         /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
+        /// <param name="GlobalConfig">The current global configuration.</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> throw exceptions on errors.</param>
-        public void LoadLedControlFiles(IList<string> LedControlFilenames, string RomName, bool ThrowExceptions = false)
+        public void LoadLedControlFiles(IList<string> LedControlFilenames, string RomName, GlobalConfig GlobalConfig, bool ThrowExceptions = false)
         {
             for (int i = 0; i < LedControlFilenames.Count; i++)
             {
-                LoadLedControlFile(LedControlFilenames[i], i + 1, RomName, ThrowExceptions);
+                LoadLedControlFile(LedControlFilenames[i], i + 1, RomName, GlobalConfig, ThrowExceptions);
             }
         }
 
@@ -68,12 +69,13 @@ namespace DirectOutput.LedControl.Loader
         /// </summary>
         /// <param name="LedControlIniFiles">The dictionary of ini files to be loaded.</param>
         /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
+        /// <param name="GlobalConfig">The current global configuration.</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> throw exceptions on errors.</param>
-        public void LoadLedControlFiles(Dictionary<int, FileInfo> LedControlIniFiles, string RomName, bool ThrowExceptions = false)
+        public void LoadLedControlFiles(Dictionary<int, FileInfo> LedControlIniFiles, string RomName, GlobalConfig GlobalConfig, bool ThrowExceptions = false)
         {
             foreach (KeyValuePair<int,FileInfo> F in LedControlIniFiles)
             {
-                LoadLedControlFile(F.Value.FullName, F.Key, RomName, ThrowExceptions);
+                LoadLedControlFile(F.Value.FullName, F.Key, RomName, GlobalConfig, ThrowExceptions);
             }
         }
 
@@ -84,12 +86,13 @@ namespace DirectOutput.LedControl.Loader
         /// <param name="LedControlFilename">The ledcontrol.ini filename.</param>
         /// <param name="LedWizNumber">The number of the LedWizEquivalent to be used for the output of the configuration in the file.</param>
         /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
+        /// <param name="GlobalConfig">The current global configuration.</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> throws exceptions on errors.</param>
-        public void LoadLedControlFile(string LedControlFilename, int LedWizNumber, string RomName, bool ThrowExceptions = false)
+        public void LoadLedControlFile(string LedControlFilename, int LedWizNumber, string RomName, GlobalConfig GlobalConfig, bool ThrowExceptions = false)
         {
             Log.Write("Loading LedControl file {0}".Build(LedControlFilename));
 
-            LedControlConfig LCC = new LedControlConfig(LedControlFilename, LedWizNumber, RomName, ThrowExceptions);
+            LedControlConfig LCC = new LedControlConfig(LedControlFilename, LedWizNumber, RomName, GlobalConfig, ThrowExceptions);
             Add(LCC);
         }
 
@@ -103,11 +106,12 @@ namespace DirectOutput.LedControl.Loader
         /// </summary>
         /// <param name="LedControlFilenames">The filenames of the ledcontrol.ini files to be loaded.</param>
         /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
+        /// <param name="GlobalConfig">The current global configuration.</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> exceptions on loading the files are shown.</param>
-        public LedControlConfigList(IList<string> LedControlFilenames, string RomName, bool ThrowExceptions = false)
+        public LedControlConfigList(IList<string> LedControlFilenames, string RomName, GlobalConfig GlobalConfig, bool ThrowExceptions = false)
             : this()
         {
-            LoadLedControlFiles(LedControlFilenames, RomName, ThrowExceptions);
+            LoadLedControlFiles(LedControlFilenames, RomName, GlobalConfig, ThrowExceptions);
         }
 
 

--- a/DirectOutput/LedControl/Loader/LedControlConfigList.cs
+++ b/DirectOutput/LedControl/Loader/LedControlConfigList.cs
@@ -25,14 +25,10 @@ namespace DirectOutput.LedControl.Loader
 
             foreach (LedControlConfig LCC in this)
             {
-
-                foreach (TableConfig TC in LCC.TableConfigurations)
-                {
-                    if (TC.IsRomNameMatching(RomName))
-                    {
-                        D.Add(LCC.LedWizNumber, TC);
-                        break;
-                    }
+                TableConfig TC = LCC.TableConfigurations.GetBestMatchingConfig(RomName);
+                if (TC != null) {
+                    D.Add(LCC.LedWizNumber, TC);
+                    break;
                 }
             }
 

--- a/DirectOutput/LedControl/Loader/LedControlConfigList.cs
+++ b/DirectOutput/LedControl/Loader/LedControlConfigList.cs
@@ -28,7 +28,6 @@ namespace DirectOutput.LedControl.Loader
                 TableConfig TC = LCC.TableConfigurations.GetBestMatchingConfig(RomName);
                 if (TC != null) {
                     D.Add(LCC.LedWizNumber, TC);
-                    break;
                 }
             }
 

--- a/DirectOutput/LedControl/Loader/LedControlConfigList.cs
+++ b/DirectOutput/LedControl/Loader/LedControlConfigList.cs
@@ -23,52 +23,19 @@ namespace DirectOutput.LedControl.Loader
         {
             Dictionary<int, TableConfig> D = new Dictionary<int, TableConfig>();
 
-            bool FoundMatch = false;
             foreach (LedControlConfig LCC in this)
             {
 
                 foreach (TableConfig TC in LCC.TableConfigurations)
                 {
-                    if (RomName.ToUpper() == TC.ShortRomName.ToUpper())
+                    if (TC.IsRomNameMatching(RomName))
                     {
                         D.Add(LCC.LedWizNumber, TC);
-                        FoundMatch = true;
                         break;
                     }
                 }
             }
 
-            if (FoundMatch) return D;
-
-            foreach (LedControlConfig LCC in this)
-            {
-
-                foreach (TableConfig TC in LCC.TableConfigurations)
-                {
-                    if (RomName.ToUpper().StartsWith("{0}_".Build(TC.ShortRomName.ToUpper())))
-                    {
-                        D.Add(LCC.LedWizNumber, TC);
-                        FoundMatch = true;
-                        break;
-                    }
-                }
-            }
-
-            if (FoundMatch) return D;
-
-            foreach (LedControlConfig LCC in this)
-            {
-
-                foreach (TableConfig TC in LCC.TableConfigurations)
-                {
-                    if (RomName.StartsWith(TC.ShortRomName))
-                    {
-                        D.Add(LCC.LedWizNumber, TC);
-
-                        break;
-                    }
-                }
-            }
             return D;
         }
 
@@ -91,12 +58,13 @@ namespace DirectOutput.LedControl.Loader
         /// Loads a list of ledcontrol.ini files.
         /// </summary>
         /// <param name="LedControlFilenames">The list of ledcontrol.ini files</param>
+        /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> throw exceptions on errors.</param>
-        public void LoadLedControlFiles(IList<string> LedControlFilenames, bool ThrowExceptions = false)
+        public void LoadLedControlFiles(IList<string> LedControlFilenames, string RomName, bool ThrowExceptions = false)
         {
             for (int i = 0; i < LedControlFilenames.Count; i++)
             {
-                LoadLedControlFile(LedControlFilenames[i], i + 1, ThrowExceptions);
+                LoadLedControlFile(LedControlFilenames[i], i + 1, RomName, ThrowExceptions);
             }
         }
 
@@ -104,12 +72,13 @@ namespace DirectOutput.LedControl.Loader
         /// Loads a list of ledcontrol.ini files.
         /// </summary>
         /// <param name="LedControlIniFiles">The dictionary of ini files to be loaded.</param>
+        /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> throw exceptions on errors.</param>
-        public void LoadLedControlFiles(Dictionary<int, FileInfo> LedControlIniFiles, bool ThrowExceptions = false)
+        public void LoadLedControlFiles(Dictionary<int, FileInfo> LedControlIniFiles, string RomName, bool ThrowExceptions = false)
         {
             foreach (KeyValuePair<int,FileInfo> F in LedControlIniFiles)
             {
-                LoadLedControlFile(F.Value.FullName, F.Key, ThrowExceptions);
+                LoadLedControlFile(F.Value.FullName, F.Key, RomName, ThrowExceptions);
             }
         }
 
@@ -119,12 +88,13 @@ namespace DirectOutput.LedControl.Loader
         /// </summary>
         /// <param name="LedControlFilename">The ledcontrol.ini filename.</param>
         /// <param name="LedWizNumber">The number of the LedWizEquivalent to be used for the output of the configuration in the file.</param>
+        /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> throws exceptions on errors.</param>
-        public void LoadLedControlFile(string LedControlFilename, int LedWizNumber, bool ThrowExceptions = false)
+        public void LoadLedControlFile(string LedControlFilename, int LedWizNumber, string RomName, bool ThrowExceptions = false)
         {
             Log.Write("Loading LedControl file {0}".Build(LedControlFilename));
 
-            LedControlConfig LCC = new LedControlConfig(LedControlFilename, LedWizNumber, ThrowExceptions);
+            LedControlConfig LCC = new LedControlConfig(LedControlFilename, LedWizNumber, RomName, ThrowExceptions);
             Add(LCC);
         }
 
@@ -137,11 +107,12 @@ namespace DirectOutput.LedControl.Loader
         /// Initializes a new instance of the <see cref="LedControlConfigList"/> class.
         /// </summary>
         /// <param name="LedControlFilenames">The filenames of the ledcontrol.ini files to be loaded.</param>
+        /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> exceptions on loading the files are shown.</param>
-        public LedControlConfigList(IList<string> LedControlFilenames, bool ThrowExceptions = false)
+        public LedControlConfigList(IList<string> LedControlFilenames, string RomName, bool ThrowExceptions = false)
             : this()
         {
-            LoadLedControlFiles(LedControlFilenames, ThrowExceptions);
+            LoadLedControlFiles(LedControlFilenames, RomName, ThrowExceptions);
         }
 
 

--- a/DirectOutput/LedControl/Loader/TableConfig.cs
+++ b/DirectOutput/LedControl/Loader/TableConfig.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DirectOutput.GlobalConfiguration;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -53,13 +54,14 @@ namespace DirectOutput.LedControl.Loader
         /// </summary>
         /// <param name="LedControlData">One line of data from led control ini.</param>
         /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
+        /// <param name="GlobalConfig">The current global configuration.</param>
         /// <param name="ThrowExceptions">If set to <c>true</c> the parser will throw exceptions if something wrong is found in the data, otherwise exceptions are ignored.</param>
         /// <exception cref="System.Exception">
         /// No usable data found in line {0}.
         /// or
         /// No short Rom name found in line {0}.
         /// </exception>
-        public void ParseLedControlDataLine(string LedControlData, string RomName, bool ThrowExceptions)
+        public void ParseLedControlDataLine(string LedControlData, string RomName, GlobalConfig GlobalConfig, bool ThrowExceptions)
         {
             //mm,L88 Blink I44,L87,ON Red,S37,S7,S48,S46/S1/S2,S10/S8,S11,S4 300 I32/S8 300 I32/W15 300 2/W25 300 2,S3/S4/S8/S33,S4/S9/S14/S26/S35,S4/S5/S12/S13/S34/S36,S4/S16/S27/S28,S7 300/S4 1500/S8 300/S33 300/S35 300,S7 White/S17 Red/S18 Red/S19 Red/W26 Magenta,S7 White/S24 Green/S25 Green/W15 Lime/W44 Green,S7 White/S22 Red/S24 Green,S7 White/S21 Red/S12 Magenta/S13 Magenta/W25 Lime,S7 White/S20 Red/S23 Red/S14 Magenta/W17 Magenta
 
@@ -87,7 +89,7 @@ namespace DirectOutput.LedControl.Loader
             //Assign Romname from first column
             ShortRomName = DataColumns[0];
             //If Romname was specified check if it matches, otherwize clear ShortRomName
-            if (!IsRomNameMatching(RomName)) {
+            if (GlobalConfig.FastInitialization && !IsRomNameMatching(RomName)) {
                 ShortRomName = string.Empty;
                 return;
             }
@@ -117,6 +119,7 @@ namespace DirectOutput.LedControl.Loader
         /// </summary>
         /// <param name="LedControlData">One line of data from led control ini.</param>
         /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
+        /// <param name="GlobalConfig">The current global configuration.</param>
         /// <param name="ThrowExceptions">If set to <c>true</c> the parser will throw exceptions if something wrong is found in the data, otherwise exceptions are ignored.</param>
         /// 0
         /// <exception cref="System.Exception">
@@ -124,10 +127,10 @@ namespace DirectOutput.LedControl.Loader
         /// or
         /// No short Rom name found in line {0}.
         /// </exception>
-        public TableConfig(string LedControlData, string RomName, bool ThrowExceptions)
+        public TableConfig(string LedControlData, string RomName, GlobalConfig GlobalConfig, bool ThrowExceptions)
             : this()
         {
-            ParseLedControlDataLine(LedControlData, RomName, ThrowExceptions);
+            ParseLedControlDataLine(LedControlData, RomName, GlobalConfig, ThrowExceptions);
         }
 
 

--- a/DirectOutput/LedControl/Loader/TableConfig.cs
+++ b/DirectOutput/LedControl/Loader/TableConfig.cs
@@ -89,7 +89,7 @@ namespace DirectOutput.LedControl.Loader
             //Assign Romname from first column
             ShortRomName = DataColumns[0];
             //If Romname was specified check if it matches, otherwize clear ShortRomName
-            if (GlobalConfig?.FastInitialization ?? false && !IsRomNameMatching(RomName)) {
+            if ((GlobalConfig?.FastInitialization ?? true) && !IsRomNameMatching(RomName)) {
                 ShortRomName = string.Empty;
                 return;
             }

--- a/DirectOutput/LedControl/Loader/TableConfig.cs
+++ b/DirectOutput/LedControl/Loader/TableConfig.cs
@@ -89,7 +89,7 @@ namespace DirectOutput.LedControl.Loader
             //Assign Romname from first column
             ShortRomName = DataColumns[0];
             //If Romname was specified check if it matches, otherwize clear ShortRomName
-            if (GlobalConfig.FastInitialization && !IsRomNameMatching(RomName)) {
+            if (GlobalConfig?.FastInitialization ?? false && !IsRomNameMatching(RomName)) {
                 ShortRomName = string.Empty;
                 return;
             }

--- a/DirectOutput/LedControl/Loader/TableConfig.cs
+++ b/DirectOutput/LedControl/Loader/TableConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DirectOutput.LedControl.Loader
 {
@@ -21,7 +22,6 @@ namespace DirectOutput.LedControl.Loader
         }
 
 
-
         /// <summary>
         /// Gets or sets the columns in the table table config.
         /// </summary>
@@ -31,19 +31,35 @@ namespace DirectOutput.LedControl.Loader
         public TableConfigColumnList Columns { get; set; }
 
         /// <summary>
+        /// Return if the table config is patching a specified rom name
+        /// </summary>
+        /// <param name="RomName">The rom name to match with</param>
+        /// <returns>true if it matches, false otherwise</returns>
+        public bool IsRomNameMatching(string RomName)
+        {
+            return (
+                RomName.IsNullOrEmpty() ||
+                string.Compare(RomName, ShortRomName, StringComparison.InvariantCultureIgnoreCase) == 0 ||
+                RomName.ToUpper().StartsWith(ShortRomName.ToUpper()) ||
+                RomName.ToUpper().StartsWith("{0}_".Build(ShortRomName.ToUpper()))
+                );
+        }
+
+        /// <summary>
         /// Gets the table config from led control data.<br />
         /// Parses one line of a Ledcontrol.ini file, it should look something like<br />
         /// mm,L88 Blink I44,L87,ON Red,S37,S7,S48,S46/S1/S2,S10/S8,S11,S4 300 I32/S8 300 I32/W15 300 2/W25 300 2,S3/S4/S8/S33,S4/S9/S14/S26/S35,S4/S5/S12/S13/S34/S36,S4/S16/S27/S28,S7 300/S4 1500/S8 300/S33 300/S35 300,S7 White/S17 Red/S18 Red/S19 Red/W26 Magenta,S7 White/S24 Green/S25 Green/W15 Lime/W44 Green,S7 White/S22 Red/S24 Green,S7 White/S21 Red/S12 Magenta/S13 Magenta/W25 Lime,S7 White/S20 Red/S23 Red/S14 Magenta/W17 Magenta<br />
         /// (Looks cool for Medival Madness)
         /// </summary>
         /// <param name="LedControlData">One line of data from led control ini.</param>
+        /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
         /// <param name="ThrowExceptions">If set to <c>true</c> the parser will throw exceptions if something wrong is found in the data, otherwise exceptions are ignored.</param>
         /// <exception cref="System.Exception">
         /// No usable data found in line {0}.
         /// or
         /// No short Rom name found in line {0}.
         /// </exception>
-        public void ParseLedControlDataLine(string LedControlData, bool ThrowExceptions)
+        public void ParseLedControlDataLine(string LedControlData, string RomName, bool ThrowExceptions)
         {
             //mm,L88 Blink I44,L87,ON Red,S37,S7,S48,S46/S1/S2,S10/S8,S11,S4 300 I32/S8 300 I32/W15 300 2/W25 300 2,S3/S4/S8/S33,S4/S9/S14/S26/S35,S4/S5/S12/S13/S34/S36,S4/S16/S27/S28,S7 300/S4 1500/S8 300/S33 300/S35 300,S7 White/S17 Red/S18 Red/S19 Red/W26 Magenta,S7 White/S24 Green/S25 Green/W15 Lime/W44 Green,S7 White/S22 Red/S24 Green,S7 White/S21 Red/S12 Magenta/S13 Magenta/W25 Lime,S7 White/S20 Red/S23 Red/S14 Magenta/W17 Magenta
 
@@ -70,6 +86,11 @@ namespace DirectOutput.LedControl.Loader
             }
             //Assign Romname from first column
             ShortRomName = DataColumns[0];
+            //If Romname was specified check if it matches, otherwize clear ShortRomName
+            if (!IsRomNameMatching(RomName)) {
+                ShortRomName = string.Empty;
+                return;
+            }
 
             Columns = new TableConfigColumnList();
 
@@ -95,6 +116,7 @@ namespace DirectOutput.LedControl.Loader
         /// (Looks cool for Medival Madness)
         /// </summary>
         /// <param name="LedControlData">One line of data from led control ini.</param>
+        /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
         /// <param name="ThrowExceptions">If set to <c>true</c> the parser will throw exceptions if something wrong is found in the data, otherwise exceptions are ignored.</param>
         /// 0
         /// <exception cref="System.Exception">
@@ -102,10 +124,10 @@ namespace DirectOutput.LedControl.Loader
         /// or
         /// No short Rom name found in line {0}.
         /// </exception>
-        public TableConfig(string LedControlData, bool ThrowExceptions)
+        public TableConfig(string LedControlData, string RomName, bool ThrowExceptions)
             : this()
         {
-            ParseLedControlDataLine(LedControlData, ThrowExceptions);
+            ParseLedControlDataLine(LedControlData, RomName, ThrowExceptions);
         }
 
 

--- a/DirectOutput/LedControl/Loader/TableConfig.cs
+++ b/DirectOutput/LedControl/Loader/TableConfig.cs
@@ -40,8 +40,8 @@ namespace DirectOutput.LedControl.Loader
             return (
                 RomName.IsNullOrEmpty() ||
                 string.Compare(RomName, ShortRomName, StringComparison.InvariantCultureIgnoreCase) == 0 ||
-                RomName.ToUpper().StartsWith(ShortRomName.ToUpper()) ||
-                RomName.ToUpper().StartsWith("{0}_".Build(ShortRomName.ToUpper()))
+                RomName.StartsWith(ShortRomName, StringComparison.InvariantCultureIgnoreCase) ||
+                RomName.StartsWith("{0}_".Build(ShortRomName), StringComparison.InvariantCultureIgnoreCase)
                 );
         }
 

--- a/DirectOutput/LedControl/Loader/TableConfigList.cs
+++ b/DirectOutput/LedControl/Loader/TableConfigList.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DirectOutput.GlobalConfiguration;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -14,14 +15,15 @@ namespace DirectOutput.LedControl.Loader
         /// </summary>
         /// <param name="TableConfigDataFromLedControlIni">The table config data from led control ini.</param>
         /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
+        /// <param name="GlobalConfig">The current global configuration.</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> [throw exceptions].</param>
-        public void ParseLedcontrolData(IEnumerable<string> TableConfigDataFromLedControlIni, string RomName, bool ThrowExceptions = true)
+        public void ParseLedcontrolData(IEnumerable<string> TableConfigDataFromLedControlIni, string RomName, GlobalConfig GlobalConfig, bool ThrowExceptions = true)
         {
             foreach (string Data in TableConfigDataFromLedControlIni)
             {
                 if (!Data.IsNullOrWhiteSpace())
                 {
-                    ParseLedcontrolData(Data, RomName, ThrowExceptions);
+                    ParseLedcontrolData(Data, RomName, GlobalConfig, ThrowExceptions);
                 }
             }
         }
@@ -32,18 +34,19 @@ namespace DirectOutput.LedControl.Loader
         /// </summary>
         /// <param name="TableConfigDataLineFromLedControlIni">The table config data line from led control ini.</param>
         /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
+        /// <param name="GlobalConfig">The current global configuration.</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> [throw exceptions].</param>
         /// <exception cref="System.Exception">
         /// Could not load table config from data line: {0}
         /// or
         /// Table with ShortRomName {0} has already been loaded.
         /// </exception>
-        public void ParseLedcontrolData(string TableConfigDataLineFromLedControlIni, string RomName, bool ThrowExceptions = true)
+        public void ParseLedcontrolData(string TableConfigDataLineFromLedControlIni, string RomName, GlobalConfig GlobalConfig, bool ThrowExceptions = true)
         {
             TableConfig TC=null;
             try
             {
-                TC = new TableConfig(TableConfigDataLineFromLedControlIni, RomName, ThrowExceptions);
+                TC = new TableConfig(TableConfigDataLineFromLedControlIni, RomName, GlobalConfig, ThrowExceptions);
 
             }
             catch (Exception E)

--- a/DirectOutput/LedControl/Loader/TableConfigList.cs
+++ b/DirectOutput/LedControl/Loader/TableConfigList.cs
@@ -102,10 +102,10 @@ namespace DirectOutput.LedControl.Loader
             TableConfig bestMatchingConfig = this.FirstOrDefault(TC=>string.Compare(TC.ShortRomName, RomName, StringComparison.InvariantCultureIgnoreCase) == 0);
             if (bestMatchingConfig == null) 
             {
-                bestMatchingConfig = this.FirstOrDefault(TC => RomName.ToUpper().StartsWith("{0}_".Build(TC.ShortRomName.ToUpper())));
+                bestMatchingConfig = this.FirstOrDefault(TC => RomName.StartsWith("{0}_".Build(TC.ShortRomName), StringComparison.InvariantCultureIgnoreCase));
 
                 if (bestMatchingConfig == null) {
-                    bestMatchingConfig = this.FirstOrDefault(TC => RomName.StartsWith(TC.ShortRomName));
+                    bestMatchingConfig = this.FirstOrDefault(TC => RomName.StartsWith(TC.ShortRomName, StringComparison.InvariantCultureIgnoreCase));
                 }
             }
             return bestMatchingConfig;

--- a/DirectOutput/LedControl/Loader/TableConfigList.cs
+++ b/DirectOutput/LedControl/Loader/TableConfigList.cs
@@ -12,14 +12,15 @@ namespace DirectOutput.LedControl.Loader
         /// Parses several lines of LedControlData.
         /// </summary>
         /// <param name="TableConfigDataFromLedControlIni">The table config data from led control ini.</param>
+        /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> [throw exceptions].</param>
-        public void ParseLedcontrolData(IEnumerable<string> TableConfigDataFromLedControlIni, bool ThrowExceptions = true)
+        public void ParseLedcontrolData(IEnumerable<string> TableConfigDataFromLedControlIni, string RomName, bool ThrowExceptions = true)
         {
             foreach (string Data in TableConfigDataFromLedControlIni)
             {
                 if (!Data.IsNullOrWhiteSpace())
                 {
-                    ParseLedcontrolData(Data, ThrowExceptions);
+                    ParseLedcontrolData(Data, RomName, ThrowExceptions);
                 }
             }
         }
@@ -29,18 +30,19 @@ namespace DirectOutput.LedControl.Loader
         /// Parses a line of LedControl data contaning the config for a table.
         /// </summary>
         /// <param name="TableConfigDataLineFromLedControlIni">The table config data line from led control ini.</param>
+        /// <param name="RomName">Specify a rom name at loading stage to ignore parsing of non matching lines</param>
         /// <param name="ThrowExceptions">if set to <c>true</c> [throw exceptions].</param>
         /// <exception cref="System.Exception">
         /// Could not load table config from data line: {0}
         /// or
         /// Table with ShortRomName {0} has already been loaded.
         /// </exception>
-        public void ParseLedcontrolData(string TableConfigDataLineFromLedControlIni, bool ThrowExceptions = true)
+        public void ParseLedcontrolData(string TableConfigDataLineFromLedControlIni, string RomName, bool ThrowExceptions = true)
         {
             TableConfig TC=null;
             try
             {
-                TC = new TableConfig(TableConfigDataLineFromLedControlIni, ThrowExceptions);
+                TC = new TableConfig(TableConfigDataLineFromLedControlIni, RomName, ThrowExceptions);
 
             }
             catch (Exception E)
@@ -52,7 +54,7 @@ namespace DirectOutput.LedControl.Loader
                 }
                 
             };
-            if (TC != null)
+            if (TC != null && !TC.ShortRomName.IsNullOrEmpty())
             {
                 if (Contains(TC.ShortRomName))
                 {

--- a/DirectOutput/LedControl/Loader/TableConfigList.cs
+++ b/DirectOutput/LedControl/Loader/TableConfigList.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace DirectOutput.LedControl.Loader
 {
@@ -88,7 +89,26 @@ namespace DirectOutput.LedControl.Loader
             }
             return false;
         }
-    
-    
+
+        /// <summary>
+        /// Returns the best matching config for the provided romname
+        /// </summary>
+        /// <param name="RomName">Name of the rom.</param>
+        /// <returns>
+        ///   The TableConfig if there is one matching, otherwise, <c>null</c>.
+        /// </returns>
+        internal TableConfig GetBestMatchingConfig(string RomName)
+        {
+            TableConfig bestMatchingConfig = this.FirstOrDefault(TC=>string.Compare(TC.ShortRomName, RomName, StringComparison.InvariantCultureIgnoreCase) == 0);
+            if (bestMatchingConfig == null) 
+            {
+                bestMatchingConfig = this.FirstOrDefault(TC => RomName.ToUpper().StartsWith("{0}_".Build(TC.ShortRomName.ToUpper())));
+
+                if (bestMatchingConfig == null) {
+                    bestMatchingConfig = this.FirstOrDefault(TC => RomName.StartsWith(TC.ShortRomName));
+                }
+            }
+            return bestMatchingConfig;
+        }
     }
 }

--- a/DirectOutput/LedControl/Setup/Configurator.cs
+++ b/DirectOutput/LedControl/Setup/Configurator.cs
@@ -59,6 +59,7 @@ namespace DirectOutput.LedControl.Setup
             foreach (KeyValuePair<int, TableConfig> KV in TableConfigDict)
             {
                 int LedWizNr = KV.Key;
+                Log.Write($"Setup table for LedWiz #{LedWizNr}");
                 if (ToyAssignments.ContainsKey(LedWizNr))
                 {
                     TableConfig TC = KV.Value;

--- a/DirectOutput/Pinball.cs
+++ b/DirectOutput/Pinball.cs
@@ -274,7 +274,7 @@ namespace DirectOutput
                         LedControlConfigList L = new LedControlConfigList();
                         if (LedControlIniFiles.Count > 0)
                         {
-                            L.LoadLedControlFiles(LedControlIniFiles, RomName, false);
+                            L.LoadLedControlFiles(LedControlIniFiles, RomName, GlobalConfig, false);
                             Log.Write("{0} directoutputconfig.ini or ledcontrol.ini files loaded.".Build(LedControlIniFiles.Count));
                         }
                         else

--- a/DirectOutput/Pinball.cs
+++ b/DirectOutput/Pinball.cs
@@ -274,7 +274,7 @@ namespace DirectOutput
                         LedControlConfigList L = new LedControlConfigList();
                         if (LedControlIniFiles.Count > 0)
                         {
-                            L.LoadLedControlFiles(LedControlIniFiles, false);
+                            L.LoadLedControlFiles(LedControlIniFiles, RomName, false);
                             Log.Write("{0} directoutputconfig.ini or ledcontrol.ini files loaded.".Build(LedControlIniFiles.Count));
                         }
                         else

--- a/DirectOutput/Table/Table.cs
+++ b/DirectOutput/Table/Table.cs
@@ -236,6 +236,7 @@ namespace DirectOutput.Table
         public void Init(Pinball Pinball)
         {
             this.Pinball = Pinball;
+            Bitmaps.UseCache = this.Pinball.GlobalConfig.FastInitialization;
 
             FileInfo ShapeDefinitionFile = Pinball.GlobalConfig.GetShapeDefinitionFile();
             if (ShapeDefinitionFile != null && ShapeDefinitionFile.Exists)

--- a/LedControlFileTester/LedControlFileTestWizard.cs
+++ b/LedControlFileTester/LedControlFileTestWizard.cs
@@ -65,7 +65,7 @@ namespace LedControlFileTester
                 DirectOutput.Log.Filename = TempLogFile;
                 DirectOutput.Log.Init();
 
-                LedControlConfig L = new LedControlConfig(Filename, 1, string.Empty);
+                LedControlConfig L = new LedControlConfig(Filename, 1, string.Empty, null);
 
                 DirectOutput.Log.Finish();
 

--- a/LedControlFileTester/LedControlFileTestWizard.cs
+++ b/LedControlFileTester/LedControlFileTestWizard.cs
@@ -65,7 +65,7 @@ namespace LedControlFileTester
                 DirectOutput.Log.Filename = TempLogFile;
                 DirectOutput.Log.Init();
 
-                LedControlConfig L = new LedControlConfig(Filename, 1);
+                LedControlConfig L = new LedControlConfig(Filename, 1, string.Empty);
 
                 DirectOutput.Log.Finish();
 


### PR DESCRIPTION
Some initialization speedup improvements : 

- Only parse TableConfig lines matching the requested romname (~10s gain on heavily customized generated files)
- Create "rawimage" cached files from any loaded image (including shapes file) which are then red inplace of the original in a cache subdirectory
- FastBitmap GetClip caching
- PixelData Colorize method to avoid unnecessary copies per pixel.
- Added an "Image" instrumentation for all image loading related logging + added logging to image management.
- Added FastInitialization parameter to GlobalConfig to switch all init optimizations (default to true)

@fix #11